### PR TITLE
Fix/feature

### DIFF
--- a/g3t_etl/__init__.py
+++ b/g3t_etl/__init__.py
@@ -90,14 +90,8 @@ class TransformerHelper(IdMinter):
         return _
 
     @classmethod
-    def get_official_identifier(cls, resource: Resource, system: str = None) -> Identifier:
+    def get_official_identifier(cls, resource: Resource) -> Identifier:
         """Get the official identifier from a fhir resource."""
-        #print("RESOURCE: ", resource, "TYPE: ", type(resource))
-        # if isinstance(resource.identifier, list) and len(resource.identifier) > 1:
-        #    print(resource.identifier[0].use, IDENTIFIER_USE)
-        #    _ = [_ident for _ident in resource.identifier if (_ident.system == system)][0]
-        #    print(_, "<<<< IDENTIFIER ")
-        #else:
         _ = next(iter(_ for _ in resource.identifier if _.use == IDENTIFIER_USE), None)
         assert _, f"Could not find {IDENTIFIER_USE} identifier for {resource}"
         return _

--- a/g3t_etl/__init__.py
+++ b/g3t_etl/__init__.py
@@ -90,8 +90,14 @@ class TransformerHelper(IdMinter):
         return _
 
     @classmethod
-    def get_official_identifier(cls, resource: Resource) -> Identifier:
+    def get_official_identifier(cls, resource: Resource, system: str = None) -> Identifier:
         """Get the official identifier from a fhir resource."""
+        #print("RESOURCE: ", resource, "TYPE: ", type(resource))
+        # if isinstance(resource.identifier, list) and len(resource.identifier) > 1:
+        #    print(resource.identifier[0].use, IDENTIFIER_USE)
+        #    _ = [_ident for _ident in resource.identifier if (_ident.system == system)][0]
+        #    print(_, "<<<< IDENTIFIER ")
+        #else:
         _ = next(iter(_ for _ in resource.identifier if _.use == IDENTIFIER_USE), None)
         assert _, f"Could not find {IDENTIFIER_USE} identifier for {resource}"
         return _

--- a/g3t_etl/__init__.py
+++ b/g3t_etl/__init__.py
@@ -17,6 +17,7 @@ from gen3_tracker.common import read_ndjson_file
 from nested_lookup import nested_lookup
 from pydantic import BaseModel, computed_field, ConfigDict, ValidationError, field_validator
 from pydantic_core import InitErrorDetails
+from g3t_etl.patcher import apply_patches
 logger = logging.getLogger(__name__)
 
 IDENTIFIER_USE = 'official'
@@ -252,3 +253,6 @@ def run_command(cmd: str | list[str]) -> (int, str, str):
     stdout, stderr = process.communicate()
 
     return process.returncode, stdout.decode(), stderr.decode()
+
+
+apply_patches()

--- a/g3t_etl/factory.py
+++ b/g3t_etl/factory.py
@@ -102,6 +102,26 @@ def convert_value_quantity_to_float(data):
     return data
 
 
+def convert_value_to_float(data):
+    """
+    Recursively converts all general 'entity' -> 'value' fields in a nested dictionary or list
+    from strings to float or int.
+    """
+    if isinstance(data, list):
+        return [convert_value_to_float(item) for item in data]
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, dict) and 'value' in value:
+                if isinstance(value['value'], str):
+                    if value['value'].replace('.', '').replace('-', '', 1).isdigit() and "." in value['value']:
+                        value['value'] = float(value['value'])
+                    elif value['value'].replace('.', '').replace('-', '', 1).isdigit() and "." not in value['value']:
+                        value['value'] = int(value['value'])
+            else:
+                data[key] = convert_value_to_float(value)
+    return data
+
+
 def validate_fhir_resource_from_type(resource_type: str, resource_data: dict) -> FHIRAbstractModel:
     """
     Generalized function to validate any FHIR resource type using its name.
@@ -192,7 +212,7 @@ def transform_csv(input_path: pathlib.Path,
 
                 # handle pydantic Decimal cases
                 validated_resource = convert_decimal_to_float(orjson.loads(validated_resource))
-                validated_resource = convert_value_quantity_to_float(validated_resource)
+                validated_resource = convert_value_to_float(validated_resource)
                 validated_resource = orjson.dumps(validated_resource).decode("utf-8")
 
                 if resource_type == "Observation": # if Observation - always append to the ndjson file

--- a/g3t_etl/factory.py
+++ b/g3t_etl/factory.py
@@ -69,7 +69,9 @@ def transform_csv(input_path: pathlib.Path,
         transformer = transformer_class(helper=DEFAULT_HELPER, template_helper=template_helper)
         research_study = transformer.create_research_study()
         already_seen.add(research_study.id)
-        get_emitter(emitters, research_study.resource_type, str(output_path), verbose=False).write(research_study.json() + "\n")
+        # get_emitter(emitters, research_study.resource_type, str(output_path), verbose=False).write(research_study.json() + "\n")
+        get_emitter(emitters, research_study.get_resource_type(), str(output_path), verbose=False).write(
+            research_study.json() + "\n")
         emitted_count += 1
 
     except ValidationError as e:
@@ -101,7 +103,7 @@ def transform_csv(input_path: pathlib.Path,
                 if resource.id in already_seen:
                     continue
                 already_seen.add(resource.id)
-                get_emitter(emitters, resource.resource_type, str(output_path), verbose=False).write(resource.json() + "\n")
+                get_emitter(emitters, resource.get_resource_type(), str(output_path), verbose=False).write(resource.json() + "\n")
                 emitted_count += 1
         except ValidationError as e:
             transformer_errors.append(e)

--- a/g3t_etl/factory.py
+++ b/g3t_etl/factory.py
@@ -1,4 +1,5 @@
 """Factory for creating a transformer."""
+import os
 import pathlib
 from typing import Callable
 
@@ -103,7 +104,20 @@ def transform_csv(input_path: pathlib.Path,
                 if resource.id in already_seen:
                     continue
                 already_seen.add(resource.id)
-                get_emitter(emitters, resource.get_resource_type(), str(output_path), verbose=False).write(resource.json() + "\n")
+                resource_type = resource.get_resource_type()
+                if resource_type == "Observation": # if Observation - always append to the ndjson file
+                    output_file = os.path.join(output_path, "Observation.ndjson")
+                    if os.path.exists(output_file): # possibly don't need this check
+                        # print(f"{output_file} exists. Appending new data to Observation.ndjson.")
+                        get_emitter(emitters, resource_type, str(output_path), verbose=False, file_mode="a").write(
+                            resource.json() + "\n")
+                    else:
+                        # print(f"{output_file} does not exist. Creating a new Observation.ndjson file.")
+                        get_emitter(emitters, resource_type, str(output_path), verbose=False, file_mode="w").write(
+                            resource.json() + "\n")
+                else:
+                    get_emitter(emitters, resource_type, str(output_path), verbose=False).write(resource.json() + "\n")
+
                 emitted_count += 1
         except ValidationError as e:
             transformer_errors.append(e)

--- a/g3t_etl/factory.py
+++ b/g3t_etl/factory.py
@@ -5,7 +5,13 @@ from typing import Callable
 
 import numpy as np
 import pandas
+import orjson
+import json
+import importlib
 from pydantic import BaseModel, ConfigDict, ValidationError
+
+import decimal
+from fhir.resources.fhirresourcemodel import FHIRAbstractModel
 
 from g3t_etl import get_emitter, print_transformation_error, print_validation_error, close_emitters, Transformer
 from g3t_etl.transformer import DEFAULT_HELPER, TemplateHelper
@@ -40,6 +46,75 @@ class TransformationResults(BaseModel):
     transformer_errors: list[ValidationError]
 
 
+def remove_empty_dicts(data):
+    """
+    Recursively remove empty dictionaries and lists from nested data structures.
+    """
+    if isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            if isinstance(v, (dict, list)):
+                cleaned = remove_empty_dicts(v)
+                # keep non-empty structures or zero
+                if cleaned or cleaned == 0:
+                    new_data[k] = cleaned
+            # keep values that are not empty or zero
+            elif v or v == 0:
+                new_data[k] = v
+        return new_data
+
+    elif isinstance(data, list):
+        cleaned_list = [remove_empty_dicts(item) for item in data]
+        cleaned_list = [item for item in cleaned_list if item or item == 0]  # remove empty items
+        return cleaned_list if cleaned_list else None  # return none if list is empty
+
+    else:
+        return data
+
+
+def convert_decimal_to_float(data):
+    """Convert pydantic Decimal to float"""
+    if isinstance(data, dict):
+        return {k: convert_decimal_to_float(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [convert_decimal_to_float(item) for item in data]
+    elif isinstance(data, decimal.Decimal):
+        return float(data)
+    else:
+        return data
+
+
+def convert_value_quantity_to_float(data):
+    """
+    Recursively converts all 'valueQuantity' -> 'value' fields in a nested dictionary or list
+    from strings to floats.
+    """
+    if isinstance(data, list):
+        return [convert_value_quantity_to_float(item) for item in data]
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            if key == 'valueQuantity' and isinstance(value, dict) and 'value' in value:
+                if isinstance(value['value'], str):
+                    # and value['value'].replace('.', '', 1).isdigit():
+                    value['value'] = float(value['value'])
+            else:
+                data[key] = convert_value_quantity_to_float(value)
+    return data
+
+
+def validate_fhir_resource_from_type(resource_type: str, resource_data: dict) -> FHIRAbstractModel:
+    """
+    Generalized function to validate any FHIR resource type using its name.
+    """
+    try:
+        resource_module = importlib.import_module(f"fhir.resources.{resource_type.lower()}")
+        resource_class = getattr(resource_module, resource_type)
+        return resource_class.model_validate(resource_data)
+
+    except (ImportError, AttributeError) as e:
+        raise ValueError(f"Invalid resource type: {resource_type}. Error: {str(e)}")
+
+
 def transform_csv(input_path: pathlib.Path,
                   output_path: pathlib.Path,
                   already_seen: set = None,
@@ -72,7 +147,7 @@ def transform_csv(input_path: pathlib.Path,
         already_seen.add(research_study.id)
         # get_emitter(emitters, research_study.resource_type, str(output_path), verbose=False).write(research_study.json() + "\n")
         get_emitter(emitters, research_study.get_resource_type(), str(output_path), verbose=False).write(
-            research_study.json() + "\n")
+            research_study.model_dump_json() + "\n")
         emitted_count += 1
 
     except ValidationError as e:
@@ -105,18 +180,31 @@ def transform_csv(input_path: pathlib.Path,
                     continue
                 already_seen.add(resource.id)
                 resource_type = resource.get_resource_type()
+
+                raw_resource_json = resource.model_dump_json()
+                cleaned_resource_dict = remove_empty_dicts(orjson.loads(raw_resource_json))
+
+                try:
+                    validated_resource = validate_fhir_resource_from_type(resource_type, cleaned_resource_dict).model_dump_json()
+                except ValueError as e:
+                    print(f"Validation failed for {resource_type}: {e}")
+                    continue
+
+                # handle pydantic Decimal cases
+                validated_resource = convert_decimal_to_float(orjson.loads(validated_resource))
+                validated_resource = convert_value_quantity_to_float(validated_resource)
+                validated_resource = orjson.dumps(validated_resource).decode("utf-8")
+
                 if resource_type == "Observation": # if Observation - always append to the ndjson file
                     output_file = os.path.join(output_path, "Observation.ndjson")
                     if os.path.exists(output_file): # possibly don't need this check
-                        # print(f"{output_file} exists. Appending new data to Observation.ndjson.")
                         get_emitter(emitters, resource_type, str(output_path), verbose=False, file_mode="a").write(
-                            resource.json() + "\n")
+                            validated_resource + "\n")
                     else:
-                        # print(f"{output_file} does not exist. Creating a new Observation.ndjson file.")
                         get_emitter(emitters, resource_type, str(output_path), verbose=False, file_mode="w").write(
-                            resource.json() + "\n")
+                            validated_resource + "\n")
                 else:
-                    get_emitter(emitters, resource_type, str(output_path), verbose=False).write(resource.json() + "\n")
+                    get_emitter(emitters, resource_type, str(output_path), verbose=False).write(validated_resource + "\n")
 
                 emitted_count += 1
         except ValidationError as e:

--- a/g3t_etl/patcher.py
+++ b/g3t_etl/patcher.py
@@ -1,0 +1,32 @@
+import re
+import typing
+
+import fhir_core.types
+from annotated_types import BaseMetadata, GroupedMetadata, Le, Ge
+
+
+class Integer64(GroupedMetadata):
+    """A signed integer in the range
+    -9,223,372,036,854,775,808 to +9,223,372,036,854,775,807 (64-bit).
+    This type is defined to allow for record/time counters that can get very large"""
+
+    pattern = re.compile(r"^[0]|[-+]?[1-9][0-9]*$")
+
+    min_length: int = -9223372036854775807
+    max_length: int = 9223372036854775807
+    __visit_name__ = "integer64"
+
+    def __iter__(self) -> typing.Iterator[BaseMetadata]:
+        """ """
+        yield Le(self.max_length)
+
+        yield Ge(self.min_length)
+
+
+def apply_patches():
+    """ """
+    fhir_core.types.Integer64 = Integer64
+    fhir_core.types.Integer64Type = typing.Annotated[int, Integer64()]
+    fhir_core.types.FHIR_PRIMITIVES_MAPS[fhir_core.types.Integer64Type] = "integer64"
+    fhir_core.types.FHIR_PRIMITIVES_MAPS[fhir_core.types.Integer64] = "integer64"
+

--- a/g3t_etl/submission_dictionary.py
+++ b/g3t_etl/submission_dictionary.py
@@ -44,6 +44,8 @@ def _map_type(dtype: str) -> str:
         return 'number'
     if 'datetime' in dtype:
         return 'string'
+    if 'string' in dtype: # not sure why I needed to add this
+        return 'string'
 
     assert dtype in ['string', 'number', 'object', 'array', 'boolean', 'null'], f"unknown dtype {dtype}"
 

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -564,11 +564,11 @@ class FHIRTransformer(BaseModel):
                     del observation_dict['code']
                 else:
                     # print("empty or invalid 'code' field detected, assigning default:", observation_dict['code'])
-                    if "Specimen" in focus_reference:
+                    if "Specimen" in focus_reference.reference:
                         code = self.populate_codeable_concept(system="https://loinc.org/",
                                                               code="68992-7",
                                                               display="Specimen-related information panel")
-                    elif "Patient" in focus_reference:
+                    elif "Patient" in focus_reference.reference:
                         code = self.populate_codeable_concept(system="https://loinc.org/",
                                                               code="68992-7",
                                                               display="Specimen-related information panel")

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -314,7 +314,6 @@ class FHIRTransformer(BaseModel):
         specimen_identifier = []
         identifier = None
         if isinstance(specimen_mapping['identifier'].value, list):
-            # pick the identifier with same system - temporary fix
             identifier = [_i for _i in specimen_mapping['identifier'].value if _i.system == self._helper.system][0]
             specimen_identifier = specimen_mapping['identifier'].value
         else:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -722,7 +722,7 @@ class FHIRTransformer(BaseModel):
 
     def observation_identifier(self, field, focus, subject):
         subject_identifier = self._helper.get_official_identifier(subject).value
-        focus_identifier = self._helper.get_official_identifier(focus, system=self._helper.system).value
+        focus_identifier = self._helper.get_official_identifier(focus).value
         if field:
             identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
         else:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -32,6 +32,7 @@ from fhir.resources.substance import Substance
 from fhir.resources.substancedefinition import SubstanceDefinition, SubstanceDefinitionStructure, \
     SubstanceDefinitionStructureRepresentation, SubstanceDefinitionName
 from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources import get_fhir_model_class
 from jinja2 import Environment, FileSystemLoader, select_autoescape, PackageLoader
 from pydantic import ConfigDict
 from pydantic.fields import FieldInfo
@@ -193,7 +194,7 @@ class FHIRTransformer(BaseModel):
         self.SYSTEM_SNOME = 'http://snomed.info/sct'
         self.SYSTEM_LOINC = 'http://loinc.org'
         self.SYSTEM_chEMBL = 'https://www.ebi.ac.uk/chembl'
-        
+
     def render_template(self, template_name: str) -> dict:
         """Render a template, populated with transformer's values."""
         # dispatch to template_helper
@@ -955,6 +956,53 @@ def register() -> None:
     )
 
 '''
+
+
+def is_valid_fhir_resource_type(resource_type):
+    """gets FHIR resource type string name"""
+    try:
+        model_class = get_fhir_model_class(resource_type)
+        return model_class is not None
+    except KeyError:
+        return False
+
+
+def create_or_extend(new_items, folder_path='META', resource_type='Observation', update_existing=False):
+    """create or extend onto an existing FHIR resource ndjson file """
+    assert is_valid_fhir_resource_type(resource_type), f"Invalid resource type: {resource_type}"
+
+    file_name = "".join([resource_type, ".ndjson"])
+    file_path = os.path.join(folder_path, file_name)
+
+    file_existed = os.path.exists(file_path)
+
+    existing_data = {}
+
+    if file_existed:
+        with open(file_path, 'r') as file:
+            for line in file:
+                try:
+                    item = orjson.loads(line)
+                    existing_data[item.get("id")] = item
+                except orjson.JSONDecodeError:
+                    continue
+
+    for new_item in new_items:
+        new_item_id = new_item["id"]
+        if new_item_id not in existing_data or update_existing:
+            existing_data[new_item_id] = new_item
+
+    with open(file_path, 'w') as file:
+        for item in existing_data.values():
+            file.write(orjson.dumps(item).decode('utf-8') + '\n')
+
+    if file_existed:
+        if update_existing:
+            print(f"{file_name} has new updates to existing data.")
+        else:
+            print(f"{file_name} has been extended, without updating existing data.")
+    else:
+        print(f"{file_name} has been created.")
 
 
 def generate_transformer(submission_source_path: pathlib.Path, overwrite: bool = False) -> None:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -539,16 +539,17 @@ class FHIRTransformer(BaseModel):
             # this is when we want to create an observation for each attribute in the row
             identifier = None
             if not observation_identifier:
-                if observation_components:
-                    identifier = self.observation_identifier(field=None, focus=focus, subject=subject)
-                else:
-                    identifier = self.observation_identifier(field, focus, subject)
-                    if 'fhir_resource_type' in field_info.json_schema_extra and field_info.json_schema_extra['fhir_resource_type'] == 'Observation.identifier':
-                        value = getattr(self, field)
+
+                identifier = self.observation_identifier(field, focus, subject)
+                if 'fhir_resource_type' in field_info.json_schema_extra and field_info.json_schema_extra['fhir_resource_type'] == 'Observation.identifier':
+                    value = getattr(self, field)
                     # this is when we want to create an observation all attributes in the row
-                        identifier = self.observation_identifier(value, focus, subject)
+                    identifier = self.observation_identifier(value, focus, subject)
             else:
                 identifier = observation_identifier
+
+            if observation_components:
+                identifier = self.observation_identifier(field=None, focus=focus, subject=subject)
 
             assert identifier, f"Can't proceed, Observation with focus: {focus} is missing Identifier."
             id_ = self.mint_id(identifier=identifier, resource_type='Observation')

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -396,10 +396,10 @@ class FHIRTransformer(BaseModel):
         specimen.identifier = specimen_identifier
         specimen.id = self.mint_id(identifier=identifier, resource_type='Specimen')
 
-        practitioner = next(iter([_ for _ in generated_resources if _.resource_type == 'Practitioner']), None)
+        practitioner = next(iter([_ for _ in generated_resources if _.get_resource_type() == 'Practitioner']), None)
 
         if not organization:
-            organization = next(iter([_ for _ in generated_resources if _.resource_type == 'Organization']), None)
+            organization = next(iter([_ for _ in generated_resources if _.get_resource_type() == 'Organization']), None)
 
         if practitioner:
             if not specimen.collection:
@@ -1001,7 +1001,7 @@ class FHIRTransformer(BaseModel):
                         'observation_subject']:
                         focus_resource_type = field_info.json_schema_extra['observation_subject']
                 else:
-                    focus_resource_type = focus.resource_type
+                    focus_resource_type = focus.get_resource_type()
                 if focus_resource_type == None and isinstance(focus, list):
                     for focus_item in focus:
                         resource_type.append(focus_item.get_resource_type())

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -756,14 +756,6 @@ class FHIRTransformer(BaseModel):
                     field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
                 medication_name = getattr(self, field)
 
-                #if not medication_name:
-                    # print(field_info.json_schema_extra)
-                 #   continue
-
-                # for med in _medications:
-                #     if med.code.coding[0].code == medication_name:
-                #         medication = med
-
                 drug_chembl_data = self.fetch_chembl_data([medication_name], limit=50)
 
                 if drug_chembl_data:
@@ -781,7 +773,6 @@ class FHIRTransformer(BaseModel):
                                                     _substance=substance,
                                                     generated_resources=generated_resources)
                 if medication:
-                    print(medication.json())
                     generated_resources.append(medication)
 
             if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.reason.concept":
@@ -825,7 +816,7 @@ class FHIRTransformer(BaseModel):
                 med_admin_dosage = MedicationAdministrationDosage(**{"dose": total_dose_quantity,
                                                                      "route": dose_route_code,
                                                                      "rateQuantity": dose_rate_quantity})
-                print(f"MedicationAdministration dosage: {med_admin_dosage.json()}")
+                # print(f"MedicationAdministration dosage: {med_admin_dosage.json()}")
 
             if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.note":
                 note_content = getattr(self, field)
@@ -877,9 +868,6 @@ class FHIRTransformer(BaseModel):
 
         if not medication:
             # information not in chembl
-            # print(f"Medication {medication_name}, with object type {type(medication_name)} wasn't found in CHebml.")
-            # print(f"adding Medication with research project's system definition")
-
             med_identifier = Identifier(
                 **{"system": self._helper.system, "value": medication_name, "use": "official"})
 
@@ -930,7 +918,7 @@ class FHIRTransformer(BaseModel):
 
         if med_admin:
             generated_resources.append(med_admin)
-            print(med_admin.json(), "\n")
+            # print(med_admin.json(), "\n")
         return generated_resources
 
     def default_transform(self, research_study: ResearchStudy) -> list[Resource]:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -35,8 +35,9 @@ from fhir.resources.substance import Substance
 from fhir.resources.substancedefinition import SubstanceDefinition, SubstanceDefinitionStructure, \
     SubstanceDefinitionStructureRepresentation, SubstanceDefinitionName
 from fhir.resources.medication import Medication, MedicationIngredient
-from fhir.resources.medicationadministration import MedicationAdministration
+from fhir.resources.medicationadministration import MedicationAdministration, MedicationAdministrationDosage
 from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.annotation import Annotation
 from fhir.resources.timing import Timing, TimingRepeat
 from fhir.resources.range import Range
 from fhir.resources.quantity import Quantity
@@ -301,6 +302,7 @@ class FHIRTransformer(BaseModel):
         if organization_mapping['partOf'].value:
             program_identifier = self.populate_identifier(value=organization_mapping['partOf'].value)
             program_id = self.mint_id(identifier=program_identifier, resource_type='Organization')
+            # print(f"capturing part of {organization_mapping['partOf'].value}")
             _part_of = Reference(**{"reference": f"Organization/{program_id}"})
 
             program_organization = Organization(**{"id": program_id,
@@ -331,6 +333,7 @@ class FHIRTransformer(BaseModel):
         if "," in patient_mapping['identifier'].value:
             patient_identifier_values = patient_mapping['identifier'].value.split(',')
             patient_identifier_values = [x.strip() for x in patient_identifier_values]
+            patient_identifier_values.sort()
 
             members = []
             for group_member_identifier in patient_identifier_values:
@@ -343,7 +346,9 @@ class FHIRTransformer(BaseModel):
                 members.append(
                     GroupMember(**{'entity': Reference(**{"reference": f"Patient/{patient_group_member.id}"})}))
 
-            group_identifier = self.populate_identifier(value=patient_mapping['identifier'].value)
+            # order of comma seperated values may change the mint id
+            # sort the identifiers
+            group_identifier = self.populate_identifier(value=','.join(patient_identifier_values))
             group_id = self.mint_id(identifier=group_identifier, resource_type='Group')
             group = Group(**{'id': group_id, "identifier": [group_identifier], "membership": 'definitional',
                              'member': members, "type": "person"})
@@ -363,7 +368,7 @@ class FHIRTransformer(BaseModel):
         return patient
 
     def create_specimen(self, patient: Patient | None, generated_resources: list[Resource],
-                        group: Group | None) -> Specimen | None:
+                        group: Group | None, organization: Organization | None) -> Specimen | None:
         """Create a specimen."""
         if 'Specimen' not in self.resource_mapping:
             return None
@@ -392,7 +397,9 @@ class FHIRTransformer(BaseModel):
         specimen.id = self.mint_id(identifier=identifier, resource_type='Specimen')
 
         practitioner = next(iter([_ for _ in generated_resources if _.resource_type == 'Practitioner']), None)
-        organization = next(iter([_ for _ in generated_resources if _.resource_type == 'Organization']), None)
+
+        if not organization:
+            organization = next(iter([_ for _ in generated_resources if _.resource_type == 'Organization']), None)
 
         if practitioner:
             if not specimen.collection:
@@ -627,9 +634,7 @@ class FHIRTransformer(BaseModel):
                             "code": code})
 
     def create_medication(self, compound_name: Optional[str], treatment_type: Optional[str],
-                          _substance: Optional[Substance]) -> Medication:
-        code = None
-        med_identifier = None
+                          _substance: Optional[Substance], generated_resources: list[Resource]) -> Medication:
 
         if compound_name:
             if ":" in compound_name:
@@ -665,62 +670,184 @@ class FHIRTransformer(BaseModel):
                              "code": code,
                              "ingredient": ingredients})
 
-    def create_medication_administration(self, patient: Patient, generated_resources: list[Resource]) -> MedicationAdministration | None:
-        # if treatment type or drug name exists - make MedicationAdministration
-        # if treatment end index days exists, then status -> completed, else status is defined by user (matching fhir requirnments) or unknown
-        # if drug name is null, then Medication.code -> snomed_code: Unknown 261665006
-        # Medication.ingredient.item -> Substance.code -> SubstanceDefinition
-        # status, medication , subject are required by FHIR
+    def chembl2medication(self, generate_resources: list[Resource]):
+        # duplicate attempt to pull out query logic
+        medications = []
+
+        for field, field_info in self.model_fields.items():
+            if not field_info.json_schema_extra:
+                continue
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or \
+                    field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
+                medication_name = getattr(self, field)
+                if medication_name:
+                    medications.append(medication_name)
+
+        chembl_information = self.fetch_chembl_data(medications, limit=1000)
+
+        if chembl_information:
+            drug_name = []
+            for row in chembl_information:
+                if 'COMPOUND_NAME' in row and row['COMPOUND_NAME'] is not None:
+                    drug_name.append(row['COMPOUND_NAME'])
+            study_drugs = list(set(drug_name))
+
+            for medication_name in study_drugs:
+                drug_chembl_data = []
+                for row in chembl_information:
+                    if ('COMPOUND_NAME' in row and row['COMPOUND_NAME']
+                            is not None and row['COMPOUND_NAME'] == medication_name):
+                        drug_chembl_data.append(row)
+
+                if drug_chembl_data:
+                    sdr = self.create_substance_definition_representations(drug_chembl_data)
+                    if sdr:
+                        sd = self.create_substance_definition(compound_name=medication_name, representations=sdr)
+                        if sd:
+                            generate_resources.append(sd)
+                            substance = self.create_substance(compound_name=medication_name, substance_definition=sd)
+                            if substance:
+                                generate_resources.append(substance)
+                                medication = self.create_medication(compound_name=medication_name, treatment_type=None,
+                                                                    _substance=substance,
+                                                                    generated_resources=generate_resources)
+                                if medication:
+                                    generate_resources.append(medication)
+
+            return generate_resources
+
+    def create_medication_administration(self, patient: Patient,
+                                         generated_resources: list[Resource]) -> list[Resource] | None:
+        """
+        creates MedicationAdministration
+            - if treatment type or drug name exists - make MedicationAdministration
+            - if treatment end index days exists, then status -> completed, else status is defined by user
+                (matching fhir requirnments) or unknown
+            - if drug name is null, then Medication.code -> snomed_code: Unknown 261665006
+            - Medication.ingredient.item -> Substance.code -> SubstanceDefinition
+            - status, medication, subject are required by FHIR
+        """
+        # TODO: this function runs 5s per record which can add up on 1000+ records will have to create all Medications prior to this call
 
         assert patient, f"Medication Administration requires the patient information"
 
         status = None
-        substance_definition = None
-        substance = None
         medication = None
-        medication_code = None
+        medication_name = None
         index_end = None
         index_start = None
-        reason = []
+        admin_reason = []
+        status_reason = []
+        status_reason_value = None
+        total_dose_quantity = None
+        dose_route_code = None
+        dose_rate_quantity = None
+        med_admin_dosage = None
+        substance = None
 
-        for field, field_info in self.model_fields.items():  # noqa - implementers must implement this method ie inherit from BaseModel
-            # print("Field:", field)
-            # print("field_info: ", field_info.json_schema_extra)
+        note = []
+
+        # get all medications
+        _medications = []
+        if generated_resources:
+             for _ in generated_resources:
+                 if _.resource_type == "Medication":
+                     _medications.append(_)
+        if not _medications:
+            return None
+
+        for field, field_info in self.model_fields.items():
             if not field_info.json_schema_extra:
                 continue
 
-            # if not field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or not field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
-            #     print(f"Patient: {patient.id} does not have FHIR mappings to define the medication that was administered.")
-            #     return
-
-            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or \
+                    field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
                 medication_name = getattr(self, field)
-                substance = None
 
-                _l = self.fetch_chembl_data([medication_name], limit=10) # TODO: do this once on all - have the user pass list - separate from medadmin
-                if _l:
-                    sdr = self.create_substance_definition_representations(_l)
+                #if not medication_name:
+                    # print(field_info.json_schema_extra)
+                 #   continue
+
+                # for med in _medications:
+                #     if med.code.coding[0].code == medication_name:
+                #         medication = med
+
+                drug_chembl_data = self.fetch_chembl_data([medication_name], limit=50)
+
+                if drug_chembl_data:
+                    sdr = self.create_substance_definition_representations(drug_chembl_data)
                     if sdr:
                         sd = self.create_substance_definition(compound_name=medication_name, representations=sdr)
                         if sd:
+                            generated_resources.append(sd)
                             substance = self.create_substance(compound_name=medication_name, substance_definition=sd)
+                            if substance:
+                                generated_resources.append(substance)
 
-                medication = self.create_medication(compound_name=medication_name, treatment_type=None, _substance=substance)
+                # not all med have chembl information
+                medication = self.create_medication(compound_name=medication_name, treatment_type=None,
+                                                    _substance=substance,
+                                                    generated_resources=generated_resources)
                 if medication:
                     print(medication.json())
+                    generated_resources.append(medication)
 
             if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.reason.concept":
-                reason_value = getattr(self, field)
-                reason = [CodeableReference(
-                    **{"concept": CodeableConcept(**{"coding": [{"code": reason_value, "system": self._helper.system, "display": reason_value}]})})]
+                admin_reason_value = getattr(self, field)
+                if admin_reason_value:
+                    admin_reason = [CodeableReference(
+                        **{"concept": CodeableConcept(**{
+                            "coding": [{"code": admin_reason_value,
+                                        "system": self._helper.system,
+                                        "display": admin_reason_value}]})})]
 
-            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
-                index_end = getattr(self, field)
-                # TODO: need a more general way to define the concept of (index) Days to Treatment End
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.statusReason":
+                status_reason_value = getattr(self, field)
+
+                if status_reason_value:
+                    status_reason = [CodeableConcept(**{"coding": [{
+                        "code": status_reason_value,
+                        "system": self._helper.system,
+                        "display": status_reason_value}]})]
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.dosage.dose":
+                total_dose = getattr(self, field)
+                if total_dose:
+                    total_dose_quantity = Quantity(**{"value": round(total_dose, 2)})
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.dosage.rateQuantity":
+                dose_rate = getattr(self, field)
+                if dose_rate:
+                    dose_rate_quantity = Quantity(**{"value": round(dose_rate, 2)})
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.dosage.route":
+                dose_route = getattr(self, field)
+                dose_route_code = CodeableConcept(**{
+                    "coding": [{"code": dose_route,
+                                "system": self._helper.system,
+                                "display": dose_route}]})
+
+            if total_dose_quantity:
+                med_admin_dosage = MedicationAdministrationDosage(**{"dose": total_dose_quantity,
+                                                                     "route": dose_route_code,
+                                                                     "rateQuantity": dose_rate_quantity})
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.note":
+                note_content = getattr(self, field)
+                if note_content:
+                    note.append(Annotation(**{"text": note_content}))
+
+            if field_info.json_schema_extra[
+                'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
+                index_end = getattr(self, field)  # TODO: do we need a more general way to define treatment was completed/stopped?
                 status = "completed"
             elif field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.status":
                 status_value = getattr(self, field)
-                if status_value in ['in-progress', 'not-done', 'on-hold', 'completed', 'entered-in-error', 'stopped', 'unknown']:
+                if status_reason_value:
+                    status = 'stopped'
+                elif status_value in ['in-progress', 'not-done', 'on-hold', 'completed', 'entered-in-error', 'stopped',
+                                      'unknown']:
                     status = status_value
                 else:
                     status = "unknown"
@@ -729,30 +856,67 @@ class FHIRTransformer(BaseModel):
                 'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.low":
                 index_start = getattr(self, field)
 
-        timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(**{"low": Quantity(**{"value": 0}), "high": Quantity(**{"value": 1})})})})# place holder - required by FHIR
+        timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(**{"low": Quantity(**{"value": 0}),
+                                                                             "high": Quantity(**{
+                                                                                 "value": 1})})})})  # place holder - required by FHIR
         if index_start and index_end:
-            timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(**{"low": Quantity(**{"value": int(index_start)}), "high": Quantity(**{"value": int(index_end)})})})})
+            timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(
+                **{"low": Quantity(**{"value": int(index_start)}), "high": Quantity(**{"value": int(index_end)})})})})
 
-        medication_admin_identifier = Identifier(**{"system": self._helper.system, "use": "official",  "value": "-".join([patient.id, medication_name])})
-        medication_admin_id = self.mint_id(identifier=medication_admin_identifier, resource_type="MedicationAdministration")
+        # add in date notion to identifier
+        medication_admin_identifier = Identifier(
+            **{"system": self._helper.system, "use": "official", "value": "-".join([patient.id, medication_name])})
+        medication_admin_id = self.mint_id(identifier=medication_admin_identifier,
+                                           resource_type="MedicationAdministration")
 
         medication_code = CodeableConcept(**{"coding": [{"code": medication_name,
-                                                             "system": self._helper.system,
-                                                             "display": medication_name}]})
+                                                         "system": self._helper.system,
+                                                         "display": medication_name}]})
+
+        if not medication:
+            # information not in chembl
+            print(f"Medication {medication_name}, with object type {type(medication_name)} wasn't found in CHebml.")
+            print(f"adding Medication with research project's system definition")
+
+            med_identifier = Identifier(
+                **{"system": self._helper.system, "value": medication_name, "use": "official"})
+
+            med_id = self.mint_id(identifier=med_identifier, resource_type="Medication")
+
+            code = CodeableConcept(**{
+                "coding": [{"code": medication_name,
+                            "system": "/".join([self._helper.system, "medication"]),
+                            "display": medication_name}]})
+
+            medication = Medication(**{"id": med_id,
+                                       "identifier": [med_identifier],
+                                       "code": code})
 
         medication_codeable_reference = CodeableReference(**{"concept": medication_code, "reference": Reference(
             **{"reference": f"Medication/{medication.id}"})})
 
+        # ingredient.strengthQuantity.unit
+        # ingredient.strengthQuantity.value
+        # Identifier.secondary
+
         data = {"id": medication_admin_id,
                 "identifier": [medication_admin_identifier],
                 "status": status,
+                "statusReason": status_reason,
+                "reason": admin_reason,
                 "medication": medication_codeable_reference,
                 "subject": {
                     "reference": f"Patient/{patient.id}"
                 },
-                "occurenceTiming": timing}
+                "occurenceTiming": timing,
+                "dosage": med_admin_dosage,
+                "note": note}
 
-        return MedicationAdministration(**data)
+        med_admin = MedicationAdministration(**data)
+
+        if med_admin:
+            generated_resources.append(med_admin)
+        return generated_resources
 
     def default_transform(self, research_study: ResearchStudy) -> list[Resource]:
         """Default transformation, call this method if you don't want to implement your own transform."""
@@ -774,7 +938,7 @@ class FHIRTransformer(BaseModel):
             research_subject = self.create_research_subject(patient, research_study)
             generated_resources.extend([patient, research_subject])
 
-        specimen = self.create_specimen(patient, generated_resources, group=None)
+        specimen = self.create_specimen(patient, generated_resources, group=None, organization=organization)
         if specimen:
             generated_resources.append(specimen)
 
@@ -786,6 +950,7 @@ class FHIRTransformer(BaseModel):
         if procedure:
             generated_resources.append(procedure)
 
+        # self.chembl2medication(generated_resources)
         self.create_medication_administration(patient, generated_resources)
 
         generated_observations = []
@@ -794,7 +959,6 @@ class FHIRTransformer(BaseModel):
             if observations:
                 generated_observations.extend(observations)
         generated_resources.extend(generated_observations)
-
 
         assert all([_ for _ in generated_resources]), "Should not have a None"
         return generated_resources

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -974,7 +974,7 @@ class FHIRTransformer(BaseModel):
         assert all([_ for _ in generated_resources]), "Should not have a None"
         return generated_resources
 
-    def create_observations(self, subject, focus) -> list[Observation]:
+    def create_observations(self, subject, focus, jinja_observation_code=None) -> list[Observation]:
         """Create observations."""
         observations = []
 
@@ -1078,9 +1078,6 @@ class FHIRTransformer(BaseModel):
 
         if components and observation_focus:
             code = None
-            identifier = self.observation_identifier(field=None, focus=focus, subject=subject)
-            assert identifier, f"Can't proceed, Observation with focus: {focus} is missing Identifier."
-            id_ = self.mint_id(identifier=identifier, resource_type='Observation')
             observation_dict = self.render_template(f"Observation.yaml.jinja")
 
             if 'code' in observation_dict and not observation_code:
@@ -1105,10 +1102,19 @@ class FHIRTransformer(BaseModel):
                 code=code
             )
 
+            if jinja_observation_code:
+                field_code = jinja_observation_code
+            else:
+                field_code = code
+            identifier = self.observation_identifier(field=field_code, focus=focus, subject=subject)
+            assert identifier, f"Can't proceed, Observation with focus: {focus} is missing Identifier."
+            id_ = self.mint_id(identifier=identifier, resource_type='Observation')
+
             observation.id = id_
             observation.identifier = [identifier]
             observation.subject = self.to_reference(subject)
             observation.focus = observation_focus
+
             observation.component = components
 
             observations.append(observation)
@@ -1233,7 +1239,7 @@ class FHIRTransformer(BaseModel):
             identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
         else:
             # component dependent
-            identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}")
+            identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
         return identifier
 
     def to_quantity(self, field_info: FieldInfo, field=None, value=None) -> dict:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -24,6 +24,7 @@ from fhir.resources.observation import Observation, ObservationComponent
 from fhir.resources.patient import Patient
 from fhir.resources.group import Group, GroupMember
 from fhir.resources.practitioner import Practitioner
+from fhir.resources.humanname import HumanName
 from fhir.resources.organization import Organization
 from fhir.resources.procedure import Procedure
 from fhir.resources.reference import Reference
@@ -269,18 +270,47 @@ class FHIRTransformer(BaseModel):
 
         practioner_mapping = self.resource_mapping['Practitioner']
         assert 'identifier' in practioner_mapping, f"Practitioner must have an identifier {self}"
-        identifier = self.populate_identifier(value=practioner_mapping['identifier'].value)
-        practitioner = self.template_practitioner()
-        practitioner.id = self.mint_id(identifier=identifier, resource_type='Practitioner')
-        practitioner.identifier = [identifier]
+        if practioner_mapping['identifier'].value:
+            if not isinstance(practioner_mapping['identifier'].value, Identifier):
+                identifier = self.populate_identifier(value=str(practioner_mapping['identifier'].value))
+            else:
+                identifier = practioner_mapping['identifier'].value
+            practitioner = self.template_practitioner()
+            practitioner.id = self.mint_id(identifier=identifier, resource_type='Practitioner')
+            practitioner.identifier = [identifier]
+            practitioner.name = [HumanName(**{"text": str(identifier.value)})]
 
-        for field, info in practioner_mapping.items():
-            if field == 'identifier':
-                # already processed this
-                continue
-            setattr(practitioner, field, info['value'])
+            organization_ = self.resource_mapping['Organization']
+            has_project = False
+            if organization_ and 'identifier' in organization_.keys() and hasattr(organization_['identifier'],
+                                                                                  'value') and organization_[
+                'identifier'].value:
+                org_identifier = self.populate_identifier(value=organization_['identifier'].value.value)
+                organization_id = self.mint_id(identifier=org_identifier, resource_type='Organization')
+                if organization_id:
+                    practitioner.qualification = [{"issuer": {"reference": f"Organization/{organization_id}"},
+                                                   "code": CodeableConcept(**{"coding": [{"code": "PHD",
+                                                                                          "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
+                                                                                          "display": "Doctor of Philosophy"}]})}]
+                    has_project = True
+            if not has_project and 'partOf' in organization_.keys() and hasattr(organization_['partOf'],'value') and organization_['partOf'].value:
+                org_identifier = self.populate_identifier(value=organization_['partOf'].value)
+                organization_id = self.mint_id(identifier=org_identifier, resource_type='Organization')
+                if organization_id:
+                    practitioner.qualification = [{"issuer": {"reference": f"Organization/{organization_id}"},
+                                                   "code": CodeableConcept(**{"coding": [{"code": "PHD",
+                                                                                          "system": "http://terminology.hl7.org/CodeSystem/v2-0360",
+                                                                                          "display": "Doctor of Philosophy"}]})}]
 
-        return practitioner
+            for field, info in practioner_mapping.items():
+                if field == 'identifier':
+                    # already processed this
+                    continue
+                setattr(practitioner, field, info['value'])
+
+            return practitioner
+        else:
+            return None
 
     def create_organization(self, generated_resources: list[Resource]) -> Organization | None:
         """Create a FHIR organization."""
@@ -407,12 +437,12 @@ class FHIRTransformer(BaseModel):
                 if not specimen.collection:
                     specimen.collection = SpecimenCollection()
                 specimen.collection.collector = practitioner_reference
-        elif organization:
-            organization_reference = self.to_reference(organization)
-            if organization_reference.reference:
-                if not specimen.collection:
-                    specimen.collection = SpecimenCollection()
-                specimen.collection.collector = organization_reference
+        # elif organization:
+        #     organization_reference = self.to_reference(organization)
+        #     if organization_reference.reference:
+        #         if not specimen.collection:
+        #             specimen.collection = SpecimenCollection()
+        #         specimen.collection.collector = organization_reference
 
         for field, info in specimen_mapping.items():
             if field == 'identifier':
@@ -543,8 +573,10 @@ class FHIRTransformer(BaseModel):
     def fetch_chembl_data(compounds: list, limit: int) -> list:
         def get_chembl_compound_info(db_file_path: str, drug_names: list, _limit=limit) -> list:
             """Query Chembl COMPOUND_RECORDS by COMPOUND_NAME for FHIR Substance"""
+            assert drug_names, "The drug_names list is empty. Please provide at least one drug name."
+
             if len(drug_names) == 1:
-                _drug_names = tuple([x.upper() for x in [drug_names[0], drug_names[0]]])
+                _drug_names = f"('{drug_names[0].upper()}')"
             else:
                 _drug_names = tuple([x.upper() for x in drug_names])
 
@@ -829,7 +861,8 @@ class FHIRTransformer(BaseModel):
 
             if field_info.json_schema_extra[
                 'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
-                index_end = getattr(self, field)  # TODO: do we need a more general way to define treatment was completed/stopped?
+                index_end = getattr(self,
+                                    field)  # TODO: do we need a more general way to define treatment was completed/stopped?
                 status = "completed"
             elif field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.status":
                 status_value = getattr(self, field)
@@ -851,7 +884,6 @@ class FHIRTransformer(BaseModel):
         if index_start and index_end:
             timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(
                 **{"low": Quantity(**{"value": int(index_start)}), "high": Quantity(**{"value": int(index_end)})})})})
-
 
         # add in date notion to identifier
         medication_admin_identifier = Identifier(

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -1257,11 +1257,21 @@ class FHIRTransformer(BaseModel):
             focus_identifier = "-".join(focus_identifiers)
         else:
             focus_identifier = self._helper.get_official_identifier(focus).value
+
         if field:
-            identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
+            # print("in if", type(field), field)
+            if isinstance(field, dict):
+                if 'coding' in field.keys():
+                    field_code = field["coding"][0]['code']
+                    identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field_code}")
+                else:
+                    identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
+            else:
+                identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
         else:
             # component dependent
             identifier = self.populate_identifier(value=f"{subject_identifier}-{focus_identifier}-{field}")
+
         return identifier
 
     def to_quantity(self, field_info: FieldInfo, field=None, value=None) -> dict:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -6,10 +6,12 @@ import orjson
 import pathlib
 import shutil
 import sys
+import sqlite3
+import pandas as pd
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Callable, ClassVar, NamedTuple
+from typing import Any, Callable, ClassVar, NamedTuple, Optional
 
 import click
 import inflection
@@ -32,7 +34,12 @@ from fhir.resources.specimen import Specimen, SpecimenCollection
 from fhir.resources.substance import Substance
 from fhir.resources.substancedefinition import SubstanceDefinition, SubstanceDefinitionStructure, \
     SubstanceDefinitionStructureRepresentation, SubstanceDefinitionName
+from fhir.resources.medication import Medication, MedicationIngredient
+from fhir.resources.medicationadministration import MedicationAdministration
 from fhir.resources.codeableconcept import CodeableConcept
+from fhir.resources.timing import Timing, TimingRepeat
+from fhir.resources.range import Range
+from fhir.resources.quantity import Quantity
 from fhir.resources import get_fhir_model_class
 from jinja2 import Environment, FileSystemLoader, select_autoescape, PackageLoader
 from pydantic import ConfigDict
@@ -42,6 +49,7 @@ from pydantic import BaseModel
 from g3t_etl import TransformerHelper, Transformer
 
 logger = logging.getLogger(__name__)
+CHEMBL_DB_PATH = "/Users/sanati/KCRB/g3t_etl/resources/chembl/chembl_34.db"
 
 
 class TemplateHelper:
@@ -297,7 +305,7 @@ class FHIRTransformer(BaseModel):
 
             program_organization = Organization(**{"id": program_id,
                                                    "identifier": [program_identifier],
-                                                   "partOf": None}) # requires a lot of code change to return lits[Organization]
+                                                   "partOf": None})  # requires a lot of code change to return lits[Organization]
 
         identifier = self.populate_identifier(value=_identifier_value)
         organization = Organization(**{"id": self.mint_id(identifier=identifier, resource_type='Organization'),
@@ -369,7 +377,7 @@ class FHIRTransformer(BaseModel):
         if isinstance(specimen_mapping['identifier'].value, list):
             # case where there are multiple specimens associated with a record
             # if len(specimen_mapping['identifier'].value) > 1:
-                # print(specimen_mapping['identifier'].value)s
+            # print(specimen_mapping['identifier'].value)s
             identifier = [_i for _i in specimen_mapping['identifier'].value if _i.system == self._helper.system][0]
             specimen_identifier = specimen_mapping['identifier'].value
         else:
@@ -520,11 +528,76 @@ class FHIRTransformer(BaseModel):
         )
         return research_subject
 
+    @staticmethod
+    def fetch_chembl_data(compounds: list, limit: int) -> list:
+        def get_chembl_compound_info(db_file_path: str, drug_names: list, _limit=limit) -> list:
+            """Query Chembl COMPOUND_RECORDS by COMPOUND_NAME for FHIR Substance"""
+            if len(drug_names) == 1:
+                _drug_names = tuple([x.upper() for x in [drug_names[0], drug_names[0]]])
+            else:
+                _drug_names = tuple([x.upper() for x in drug_names])
+
+            query = f"""
+            SELECT DISTINCT 
+                a.CHEMBL_ID,
+                c.STANDARD_INCHI,
+                c.CANONICAL_SMILES,
+                cr.COMPOUND_NAME
+            FROM 
+                MOLECULE_DICTIONARY as a
+            LEFT JOIN 
+                COMPOUND_STRUCTURES as c ON a.MOLREGNO = c.MOLREGNO
+            LEFT JOIN 
+                ACTIVITIES as p ON a.MOLREGNO = p.MOLREGNO
+            LEFT JOIN 
+                compound_records as cr ON a.MOLREGNO = cr.MOLREGNO
+            LEFT JOIN
+                source as sr ON cr.SRC_ID = sr.SRC_ID
+            WHERE cr.COMPOUND_NAME IN {_drug_names}
+            LIMIT {str(_limit)};
+            """
+            conn = sqlite3.connect(db_file_path)
+            cursor = conn.cursor()
+            cursor.execute(query)
+            rows = cursor.fetchall()
+
+            conn.close()
+
+            return rows
+
+        def tuple_to_dict(keys, values):
+            return dict(zip(keys, values))
+
+        drug_compound_data = get_chembl_compound_info(db_file_path=CHEMBL_DB_PATH, drug_names=compounds)
+
+        key_info = ["CHEMBL_ID", "STANDARD_INCHI", "CANONICAL_SMILES", "COMPOUND_NAME"]
+        _dict_list = []
+        for item in drug_compound_data:
+            _dict_list.append(tuple_to_dict(key_info, item))
+        return _dict_list
+
+    @staticmethod
+    def create_substance_definition_representations(drug_data: list) -> list:
+        representations = []
+        for row in drug_data:
+            if 'STANDARD_INCHI' in row and row['STANDARD_INCHI'] is not None:
+                representations.append(SubstanceDefinitionStructureRepresentation(
+                    **{"representation": row['STANDARD_INCHI'],
+                       "format": CodeableConcept(**{"coding": [{"code": "InChI",
+                                                                "system": 'http://hl7.org/fhir/substance-representation-format',
+                                                                "display": "InChI"}]})}))
+
+            if 'CANONICAL_SMILES' in row and row['CANONICAL_SMILES'] is not None:
+                representations.append(SubstanceDefinitionStructureRepresentation(
+                    **{"representation": row['CANONICAL_SMILES'],
+                       "format": CodeableConcept(**{"coding": [{"code": "SMILES",
+                                                                "system": 'http://hl7.org/fhir/substance-representation-format',
+                                                                "display": "SMILES"}]})}))
+        return representations
+
     def create_substance_definition(self, compound_name: str, representations: list) -> SubstanceDefinition:
         sub_def_identifier = Identifier(**{"system": self.SYSTEM_chEMBL, "value": compound_name, "use": "official"})
-        sub_def_id = self.mint_id(identifier=sub_def_identifier, resource_type="SubstanceDefinition",
-                                  project_id=self.project_id,
-                                  namespace=self.NAMESPACE_HTAN)
+        sub_def_id = self.mint_id(identifier=sub_def_identifier, resource_type="SubstanceDefinition")
 
         return SubstanceDefinition(**{"id": sub_def_id,
                                       "identifier": [sub_def_identifier],
@@ -543,9 +616,7 @@ class FHIRTransformer(BaseModel):
 
         sub_identifier = Identifier(
             **{"system": self.SYSTEM_chEMBL, "value": compound_name, "use": "official"})
-        sub_id = self.mint_id(identifier=sub_identifier, resource_type="Substance",
-                              project_id=self.project_id,
-                              namespace=self.NAMESPACE_HTAN)
+        sub_id = self.mint_id(identifier=sub_identifier, resource_type="Substance")
 
         return Substance(**{"id": sub_id,
                             "identifier": [sub_identifier],
@@ -554,6 +625,134 @@ class FHIRTransformer(BaseModel):
                                                                         "system": "http://terminology.hl7.org/CodeSystem/substance-category",
                                                                         "display": "Drug or Medicament"}]})],
                             "code": code})
+
+    def create_medication(self, compound_name: Optional[str], treatment_type: Optional[str],
+                          _substance: Optional[Substance]) -> Medication:
+        code = None
+        med_identifier = None
+
+        if compound_name:
+            if ":" in compound_name:
+                compound_name.replace(":", "_")
+            code = CodeableConcept(**{"coding": [
+                {"code": compound_name, "system": "/".join([self.SYSTEM_chEMBL, "compound_name"]),
+                 "display": compound_name}]})
+
+            med_identifier = Identifier(
+                **{"system": self.SYSTEM_chEMBL, "value": compound_name, "use": "official"})
+        else:
+            if ":" in treatment_type:
+                treatment_type.replace(":", "_")
+
+            code = CodeableConcept(**{
+                "coding": [{"code": treatment_type,
+                            "system": "/".join([self._helper.system, "treatment_type"]),  # TODO: change
+                            "display": treatment_type}]})
+
+            med_identifier = Identifier(
+                **{"system": self._helper.system, "value": treatment_type, "use": "official"})
+
+        med_id = self.mint_id(identifier=med_identifier, resource_type="Medication")
+
+        ingredients = []
+        if _substance:
+            ingredients.append(MedicationIngredient(**{
+                "item": CodeableReference(
+                    **{"reference": Reference(**{"reference": f"Substance/{_substance.id}"})})}))
+
+        return Medication(**{"id": med_id,
+                             "identifier": [med_identifier],
+                             "code": code,
+                             "ingredient": ingredients})
+
+    def create_medication_administration(self, patient: Patient, generated_resources: list[Resource]) -> MedicationAdministration | None:
+        # if treatment type or drug name exists - make MedicationAdministration
+        # if treatment end index days exists, then status -> completed, else status is defined by user (matching fhir requirnments) or unknown
+        # if drug name is null, then Medication.code -> snomed_code: Unknown 261665006
+        # Medication.ingredient.item -> Substance.code -> SubstanceDefinition
+        # status, medication , subject are required by FHIR
+
+        assert patient, f"Medication Administration requires the patient information"
+
+        status = None
+        substance_definition = None
+        substance = None
+        medication = None
+        medication_code = None
+        index_end = None
+        index_start = None
+        reason = []
+
+        for field, field_info in self.model_fields.items():  # noqa - implementers must implement this method ie inherit from BaseModel
+            # print("Field:", field)
+            # print("field_info: ", field_info.json_schema_extra)
+            if not field_info.json_schema_extra:
+                continue
+
+            # if not field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or not field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
+            #     print(f"Patient: {patient.id} does not have FHIR mappings to define the medication that was administered.")
+            #     return
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.medication" or field_info.json_schema_extra['fhir_resource_type'] == "Medication.ingredient":
+                medication_name = getattr(self, field)
+                substance = None
+
+                _l = self.fetch_chembl_data([medication_name], limit=10) # TODO: do this once on all - have the user pass list - separate from medadmin
+                if _l:
+                    sdr = self.create_substance_definition_representations(_l)
+                    if sdr:
+                        sd = self.create_substance_definition(compound_name=medication_name, representations=sdr)
+                        if sd:
+                            substance = self.create_substance(compound_name=medication_name, substance_definition=sd)
+
+                medication = self.create_medication(compound_name=medication_name, treatment_type=None, _substance=substance)
+                if medication:
+                    print(medication.json())
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.reason.concept":
+                reason_value = getattr(self, field)
+                reason = [CodeableReference(
+                    **{"concept": CodeableConcept(**{"coding": [{"code": reason_value, "system": self._helper.system, "display": reason_value}]})})]
+
+            if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
+                index_end = getattr(self, field)
+                # TODO: need a more general way to define the concept of (index) Days to Treatment End
+                status = "completed"
+            elif field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.status":
+                status_value = getattr(self, field)
+                if status_value in ['in-progress', 'not-done', 'on-hold', 'completed', 'entered-in-error', 'stopped', 'unknown']:
+                    status = status_value
+                else:
+                    status = "unknown"
+
+            if field_info.json_schema_extra[
+                'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.low":
+                index_start = getattr(self, field)
+
+        timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(**{"low": Quantity(**{"value": 0}), "high": Quantity(**{"value": 1})})})})# place holder - required by FHIR
+        if index_start and index_end:
+            timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(**{"low": Quantity(**{"value": int(index_start)}), "high": Quantity(**{"value": int(index_end)})})})})
+
+        medication_admin_identifier = Identifier(**{"system": self._helper.system, "use": "official",  "value": "-".join([patient.id, medication_name])})
+        medication_admin_id = self.mint_id(identifier=medication_admin_identifier, resource_type="MedicationAdministration")
+
+        medication_code = CodeableConcept(**{"coding": [{"code": medication_name,
+                                                             "system": self._helper.system,
+                                                             "display": medication_name}]})
+
+        medication_codeable_reference = CodeableReference(**{"concept": medication_code, "reference": Reference(
+            **{"reference": f"Medication/{medication.id}"})})
+
+        data = {"id": medication_admin_id,
+                "identifier": [medication_admin_identifier],
+                "status": status,
+                "medication": medication_codeable_reference,
+                "subject": {
+                    "reference": f"Patient/{patient.id}"
+                },
+                "occurenceTiming": timing}
+
+        return MedicationAdministration(**data)
 
     def default_transform(self, research_study: ResearchStudy) -> list[Resource]:
         """Default transformation, call this method if you don't want to implement your own transform."""
@@ -587,12 +786,15 @@ class FHIRTransformer(BaseModel):
         if procedure:
             generated_resources.append(procedure)
 
+        self.create_medication_administration(patient, generated_resources)
+
         generated_observations = []
         for _ in generated_resources:
             observations = self.create_observations(subject=patient, focus=_)
             if observations:
                 generated_observations.extend(observations)
         generated_resources.extend(generated_observations)
+
 
         assert all([_ for _ in generated_resources]), "Should not have a None"
         return generated_resources
@@ -620,7 +822,8 @@ class FHIRTransformer(BaseModel):
                     resource_type = []
                     for focus_item in focus:
                         resource_type.append(focus_item.resource_type)
-                    if len(list(set(resource_type))) == 1 and resource_type[0] == field_info.json_schema_extra['observation_subject']:
+                    if len(list(set(resource_type))) == 1 and resource_type[0] == field_info.json_schema_extra[
+                        'observation_subject']:
                         focus_resource_type = field_info.json_schema_extra['observation_subject']
                 else:
                     focus_resource_type = focus.resource_type
@@ -630,7 +833,7 @@ class FHIRTransformer(BaseModel):
                     if len(list(set(resource_type))) == 1:
                         focus_resource_type = resource_type[0]
                     elif focus:
-                        focus_resource_type = focus[0].resource_type # temp solution
+                        focus_resource_type = focus[0].resource_type  # temp solution
                 if field_info.json_schema_extra['observation_subject'] == focus_resource_type:
                     observation_fields[field] = field_info
             if 'fhir_resource_type' in field_info.json_schema_extra and field_info.json_schema_extra[

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -996,7 +996,7 @@ class FHIRTransformer(BaseModel):
                 if isinstance(focus, list):
                     resource_type = []
                     for focus_item in focus:
-                        resource_type.append(focus_item.resource_type)
+                        resource_type.append(focus_item.get_resource_type())
                     if len(list(set(resource_type))) == 1 and resource_type[0] == field_info.json_schema_extra[
                         'observation_subject']:
                         focus_resource_type = field_info.json_schema_extra['observation_subject']
@@ -1004,7 +1004,7 @@ class FHIRTransformer(BaseModel):
                     focus_resource_type = focus.resource_type
                 if focus_resource_type == None and isinstance(focus, list):
                     for focus_item in focus:
-                        resource_type.append(focus_item.resource_type)
+                        resource_type.append(focus_item.get_resource_type())
                     if len(list(set(resource_type))) == 1:
                         focus_resource_type = resource_type[0]
                     elif focus:
@@ -1054,15 +1054,21 @@ class FHIRTransformer(BaseModel):
             elif 'float' in field_type or 'decimal' in field_type or 'number' in field_type:
                 component.valueQuantity = self.to_quantity(field=component_field, field_info=component_field_info,
                                                            value=component_value)
-            else:
-                component.valueString = getattr(self, component_field)
+            elif 'bool' in field_type:
+                component_value = getattr(self, component_field)
+                if isinstance(component_value, bool):
+                    component.valueBoolean = component_value
+
+            elif component_value and isinstance(getattr(self, component_field), str):
+                component_value = getattr(self, component_field)
+                component.valueString = str(component_value)
 
             if component:
                 components.append(component)
                 if isinstance(focus, list):
                     observation_focus = [self.to_reference(_f) for _f in focus]
                 else:
-                    if component_field_info.json_schema_extra['observation_subject'] == focus.resource_type:
+                    if component_field_info.json_schema_extra['observation_subject'] == focus.get_resource_type():
                         observation_focus = [
                             self.to_reference(focus)]  # should be the same focus reference for the component use-case
         if isinstance(focus, list):
@@ -1257,7 +1263,7 @@ class FHIRTransformer(BaseModel):
 
     def to_reference(self, resource: Resource) -> Reference:
         """Create a reference from a resource of the form RESOURCE/id."""
-        return Reference(reference=f"{resource.resource_type}/{resource.id}")
+        return Reference(reference=f"{resource.get_resource_type()}/{resource.id}")
 
     def to_codeable_reference(self, *args: Any, **kwargs: Any) -> CodeableReference:
         """Create a reference from a resource of the form RESOURCE/id."""

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -744,6 +744,7 @@ class FHIRTransformer(BaseModel):
         dose_rate_quantity = None
         med_admin_dosage = None
         substance = None
+        secondary_identifier = None
 
         note = []
 
@@ -831,6 +832,13 @@ class FHIRTransformer(BaseModel):
                 if note_content:
                     note.append(Annotation(**{"text": note_content}))
 
+            # TODO: move this out - STUDY SPECIFIC
+            if field_info.json_schema_extra['fhir_resource_type'] == "Identifier.secondary":
+                ident_value = getattr(self, field)
+                if ident_value:
+                    secondary_identifier = Identifier(**{"system": "/".join([self._helper.system, "regimen"]), "use": "secondary", "value": ident_value})
+                    print(f"IDENTIFIER REGIM: {ident_value}, {secondary_identifier}")
+
             if field_info.json_schema_extra[
                 'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
                 index_end = getattr(self, field)  # TODO: do we need a more general way to define treatment was completed/stopped?
@@ -856,6 +864,7 @@ class FHIRTransformer(BaseModel):
             timing = Timing(**{"repeat": TimingRepeat(**{"boundsRange": Range(
                 **{"low": Quantity(**{"value": int(index_start)}), "high": Quantity(**{"value": int(index_end)})})})})
 
+
         # add in date notion to identifier
         medication_admin_identifier = Identifier(
             **{"system": self._helper.system, "use": "official", "value": "-".join([patient.id, medication_name])})
@@ -868,8 +877,8 @@ class FHIRTransformer(BaseModel):
 
         if not medication:
             # information not in chembl
-            print(f"Medication {medication_name}, with object type {type(medication_name)} wasn't found in CHebml.")
-            print(f"adding Medication with research project's system definition")
+            # print(f"Medication {medication_name}, with object type {type(medication_name)} wasn't found in CHebml.")
+            # print(f"adding Medication with research project's system definition")
 
             med_identifier = Identifier(
                 **{"system": self._helper.system, "value": medication_name, "use": "official"})
@@ -891,9 +900,21 @@ class FHIRTransformer(BaseModel):
         # ingredient.strengthQuantity.unit
         # ingredient.strengthQuantity.value
         # Identifier.secondary
+        _identifiers = []
+        if secondary_identifier:
+            _identifiers.append(secondary_identifier)
+        if medication_admin_identifier:
+            _identifiers.append(medication_admin_identifier)
+
+        # TODO: move this out - STUDY SPECIFIC
+        if index_start:
+            time_identifier = Identifier(
+                **{"system": "/".join([self._helper.system, "index_date_start_days"]), "use": "secondary", "value": index_start})
+            if time_identifier:
+                _identifiers.append(time_identifier)
 
         data = {"id": medication_admin_id,
-                "identifier": [medication_admin_identifier],
+                "identifier": _identifiers,
                 "status": status,
                 "statusReason": status_reason,
                 "reason": admin_reason,
@@ -909,6 +930,7 @@ class FHIRTransformer(BaseModel):
 
         if med_admin:
             generated_resources.append(med_admin)
+            print(med_admin.json(), "\n")
         return generated_resources
 
     def default_transform(self, research_study: ResearchStudy) -> list[Resource]:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -402,13 +402,17 @@ class FHIRTransformer(BaseModel):
             organization = next(iter([_ for _ in generated_resources if _.get_resource_type() == 'Organization']), None)
 
         if practitioner:
-            if not specimen.collection:
-                specimen.collection = SpecimenCollection()
-            specimen.collection.collector = self.to_reference(practitioner)
+            practitioner_reference = self.to_reference(practitioner)
+            if practitioner_reference.reference:
+                if not specimen.collection:
+                    specimen.collection = SpecimenCollection()
+                specimen.collection.collector = practitioner_reference
         elif organization:
-            if not specimen.collection:
-                specimen.collection = SpecimenCollection()
-            specimen.collection.collector = self.to_reference(organization)
+            organization_reference = self.to_reference(organization)
+            if organization_reference.reference:
+                if not specimen.collection:
+                    specimen.collection = SpecimenCollection()
+                specimen.collection.collector = organization_reference
 
         for field, info in specimen_mapping.items():
             if field == 'identifier':

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -729,7 +729,6 @@ class FHIRTransformer(BaseModel):
             - status, medication, subject are required by FHIR
         """
         # TODO: this function runs 5s per record which can add up on 1000+ records will have to create all Medications prior to this call
-
         assert patient, f"Medication Administration requires the patient information"
 
         status = None
@@ -747,15 +746,6 @@ class FHIRTransformer(BaseModel):
         substance = None
 
         note = []
-
-        # get all medications
-        _medications = []
-        if generated_resources:
-             for _ in generated_resources:
-                 if _.resource_type == "Medication":
-                     _medications.append(_)
-        if not _medications:
-            return None
 
         for field, field_info in self.model_fields.items():
             if not field_info.json_schema_extra:
@@ -823,6 +813,8 @@ class FHIRTransformer(BaseModel):
 
             if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.dosage.route":
                 dose_route = getattr(self, field)
+                if not dose_route:
+                    dose_route = "Unknown"
                 dose_route_code = CodeableConcept(**{
                     "coding": [{"code": dose_route,
                                 "system": self._helper.system,
@@ -832,6 +824,7 @@ class FHIRTransformer(BaseModel):
                 med_admin_dosage = MedicationAdministrationDosage(**{"dose": total_dose_quantity,
                                                                      "route": dose_route_code,
                                                                      "rateQuantity": dose_rate_quantity})
+                print(f"MedicationAdministration dosage: {med_admin_dosage.json()}")
 
             if field_info.json_schema_extra['fhir_resource_type'] == "MedicationAdministration.note":
                 note_content = getattr(self, field)
@@ -951,7 +944,15 @@ class FHIRTransformer(BaseModel):
             generated_resources.append(procedure)
 
         # self.chembl2medication(generated_resources)
-        self.create_medication_administration(patient, generated_resources)
+        has_medication_mapping = any(
+            "Medication" in field_info.json_schema_extra.get('fhir_resource_type', '') or
+            "MedicationAdministration.medication" in field_info.json_schema_extra.get('fhir_resource_type', '')
+            for field, field_info in self.model_fields.items()
+        )
+
+        if has_medication_mapping:
+            print("Creating MedicationAdministration----")
+            self.create_medication_administration(patient, generated_resources)
 
         generated_observations = []
         for _ in generated_resources:

--- a/g3t_etl/transformer.py
+++ b/g3t_etl/transformer.py
@@ -827,13 +827,6 @@ class FHIRTransformer(BaseModel):
                 if note_content:
                     note.append(Annotation(**{"text": note_content}))
 
-            # TODO: move this out - STUDY SPECIFIC
-            if field_info.json_schema_extra['fhir_resource_type'] == "Identifier.secondary":
-                ident_value = getattr(self, field)
-                if ident_value:
-                    secondary_identifier = Identifier(**{"system": "/".join([self._helper.system, "regimen"]), "use": "secondary", "value": ident_value})
-                    print(f"IDENTIFIER REGIM: {ident_value}, {secondary_identifier}")
-
             if field_info.json_schema_extra[
                 'fhir_resource_type'] == "MedicationAdministration.occurrenceTiming.boundsRange.high":
                 index_end = getattr(self, field)  # TODO: do we need a more general way to define treatment was completed/stopped?
@@ -891,19 +884,12 @@ class FHIRTransformer(BaseModel):
 
         # ingredient.strengthQuantity.unit
         # ingredient.strengthQuantity.value
-        # Identifier.secondary
-        _identifiers = []
-        if secondary_identifier:
-            _identifiers.append(secondary_identifier)
-        if medication_admin_identifier:
-            _identifiers.append(medication_admin_identifier)
 
-        # TODO: move this out - STUDY SPECIFIC
-        if index_start:
-            time_identifier = Identifier(
-                **{"system": "/".join([self._helper.system, "index_date_start_days"]), "use": "secondary", "value": index_start})
-            if time_identifier:
-                _identifiers.append(time_identifier)
+        _identifiers = []
+        if self.medication_administration_identifier:
+            _identifiers = self.medication_administration_identifier
+        elif medication_admin_identifier:
+            _identifiers.append(medication_admin_identifier)
 
         data = {"id": medication_admin_id,
                 "identifier": _identifiers,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gen3_tracker>=0.0.4rc36
+gen3-tracker>=0.0.7rc2
 click
 pandas
 numpy

--- a/resources/chembl/.gitignore
+++ b/resources/chembl/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1rc22',  # Required
+    version='0.0.1rc23',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1rc23',  # Required
+    version='0.0.1rc24',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Specimen Enhancements:
- Added a parent reference to the Specimen resource.
- Implemented a function to create an Organization for the Specimen collector reference, capturing a hierarchy of Lab (“sub_organization”)-> Lab (“sub_organization”)-> Organization.

Observation Enhancements:
- Introduced a general Observation code for Specimens, used when no code exists or is not captured through Jinja templates.
- Enhanced Observation.component handling to support a list of CodeableReferences instead of creating one Observation per a general context.
- Fixed the Observation.focus reference to correctly point to the entity that the Observation components focus is on.

Specimen Identifiers:
- Added support for multiple identifiers for Specimen resources. Needs to be generalized to all FHIR entities in the next PRs.

MedicationAdministration to SubstanceDefinition:
- Added support for Substance and SubstanceDefinition resources, based on drug names found in the ChEMBL database (version 34, located at ./resources/chembl/chemble_34.db).
- Created a workflow linking MedicationAdministration -> Medication -> Substance -> SubstanceDefinition entities in FHIR.
Note: The current workflow involves SQL-based searches in ChEMBL per row and includes regimen and index start date days identifiers that are use-case specific. It’s the functional workflow etl, it is not ideal and could be optimized in future PRs.